### PR TITLE
Added word and sentence(s)

### DIFF
--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -24,6 +24,8 @@ The following validators are provided:
 * numeric
 * required
 * requiredIf
+* word
+* sentences
 
 ## Custom
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -224,3 +224,25 @@ export function max(maximum: number, message?: string): Validator {
     execute: executeMax(maximum)
   }
 }
+
+const WORD_REGEX = /^[a-zA-Z]+$/
+
+export function word(message?: string): Validator {
+  if(!message) message = 'Must be a word'
+  return {
+    name: 'word',
+    message: message,
+    execute: match(WORD_REGEX).execute
+  }
+}
+
+const SENTENCE_REGEX = /((?:[A-Z]\.|[^\.!?])+)[\.!?]/g
+
+export function sentences(message?: string): Validator {
+  if(!message) message = 'Must be a sentence with punctuation'
+  return {
+    name: 'sentence(s)',
+    message: message,
+    execute: match(SENTENCE_REGEX).execute
+  }
+}

--- a/tests/validators/sentence.spec.ts
+++ b/tests/validators/sentence.spec.ts
@@ -1,0 +1,43 @@
+import { sentences } from '../../src'
+
+describe('email validator', () => {
+
+  const validSentences = [
+    'Hello.',
+    'Hello my name is tom.',
+    'Hello, my name is tom @ tom.com. I live a in a new world.',
+    'I thought it was all fake, for the show. I thought it was all fake, for the show. I thought it was all fake, for the show.',
+    'I thought it was all fake, for the show! I thought it was all fake, for the show? I thought it was all fake, for the show.'
+  ]
+
+  const invalidSentences = [
+    'asdf ASDF',
+    '. Whats up',
+    'Yo)',
+    'I thought it was all fake, for the show ',
+    'this is totally cool,'
+  ]
+
+  validSentences.forEach(value => {
+    it(`returns true when valid sentences: ${value}`, () => {
+      expect(sentences().execute(value)).toBe(true)
+    })
+  })
+
+  invalidSentences.forEach(value => {
+    it(`returns false when invalid sentences: ${value}`, () => {
+      expect(sentences().execute(value)).toBe(false)
+    })
+  })
+
+  it('provides default message', () => {
+    const validator = sentences()
+    expect(validator.message).toBe('Must be a sentence with punctuation')
+  })
+
+  it('uses custom message', () => {
+    const validator = sentences('custom message')
+    expect(validator.message).toBe('custom message')
+  })
+
+})

--- a/tests/validators/word.spec.ts
+++ b/tests/validators/word.spec.ts
@@ -1,0 +1,44 @@
+import { word } from '../../src'
+
+describe('word validator', () => {
+
+  const validLetters = [
+    'asdf',
+    'ASDF',
+    'asdfASDF',
+    'helloWorld'
+  ]
+
+  const invalidLetters = [
+    'asdf ASDF',
+    ' asdf',
+    '!@#asdf',
+    'ASDFasdf!',
+    'ASDF!asdf',
+    '!!@#$%^&*()__+',
+    'hello world.'
+  ]
+
+  validLetters.forEach(value => {
+    it(`returns true when valid letters: ${value}`, () => {
+      expect(word().execute(value)).toBe(true)
+    })
+  })
+
+  invalidLetters.forEach(value => {
+    it(`returns false when invalid letters: ${value}`, () => {
+      expect(word().execute(value)).toBe(false)
+    })
+  })
+
+  it('provides default message', () => {
+    const validator = word()
+    expect(validator.message).toBe('Must be a word')
+  })
+
+  it('uses custom message', () => {
+    const validator = word('custom message')
+    expect(validator.message).toBe('custom message')
+  })
+
+})


### PR DESCRIPTION
This is simply a word and sentence regex for text inputs. It allows for custom messages. The sentence validation requires actual sentence punctuation which could eventually be made as an optional feature. Word basically requires that the input is letters only. 