### PR TITLE
v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.5] - 2022-03-08
+
+* Update `Field` types for properties: `value`, `invalid`
+* Update `FieldGroup` type for property: `invalid`
+* Update type guards for `Field` and `FieldGroup`
+* Update api documentation
+* Bump prismjs from 1.25.0 to 1.27.0
+
 ## [1.0.4] - 2022-02-14
 
 * Bump follow-redirects from 1.13.1 to 1.14.8
@@ -36,6 +44,7 @@
   * typings
   * vitepress docs
 
+[1.0.5]: https://github.com/dev-tavern/vue-validus/releases/tag/v1.0.5
 [1.0.4]: https://github.com/dev-tavern/vue-validus/releases/tag/v1.0.4
 [1.0.3]: https://github.com/dev-tavern/vue-validus/releases/tag/v1.0.3
 [1.0.2]: https://github.com/dev-tavern/vue-validus/releases/tag/v1.0.2

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -21,7 +21,7 @@ fieldValue | T \| Ref\<T\> | (Optional) Initial value of the field.  If a Vue Re
 
 ### value
 
-- **Type**: `T | Ref<T>`
+- **Type**: `T`
 - **Details**: The current value of the field, is provided to validators upon validation.  If this is set with a Vue ref, the field and ref will maintain the same value (if the ref value changes, the field value will reflect the change as well).
 
 ### invalid
@@ -776,8 +776,8 @@ field1.validate() // false (invalid - field2 is 'yes' and field1's value is not 
 ```typescript
 interface Field<T = any> {
   __kind: 'Field'
-  value: T | Ref<T>
-  invalid: boolean | Ref<boolean>
+  value: T
+  invalid: boolean
   errors: string[]
   errorMessages: string[]
   validate(): boolean
@@ -795,10 +795,11 @@ interface Field<T = any> {
 interface FieldGroup {
   __kind: 'FieldGroup'
   fields: FieldGroupProps
-  invalid: boolean | Ref<boolean> | ComputedRef<boolean>
+  invalid: boolean
   validate(fieldName?: string): boolean
   clear(): void
   get(fieldName: string): Field | FieldGroupType | null
+  getValue(fieldName: string): any
   getErrorFields(): (Field | FieldGroupType)[]
   setTopLevel(context: FieldGroup): void
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9159,9 +9159,9 @@
       }
     },
     "prismjs": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
-      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
       "dev": true
     },
     "private": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-validus",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-validus",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Extensible lightweight validation library for Vue 3",
   "author": "Josh Gamble",
   "license": "MIT",

--- a/src/field.ts
+++ b/src/field.ts
@@ -1,15 +1,15 @@
-import { Ref, ref, unref, reactive } from 'vue'
+import { reactive, Ref, toRef, unref } from 'vue'
 import { FieldGroup, Validator } from '.'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Field<T = any> {
   __kind: 'Field'
-  value: T | Ref<T>
+  value: T
   /**
    * If the field is currently considered invalid (did not pass latest validation).  
    * `true` if invalid, `false` if valid.
    */
-  invalid: boolean | Ref<boolean>
+  invalid: boolean
   /**
    * List of failing validator names.
    */
@@ -81,21 +81,19 @@ function internalValidate(fieldObj: Field, validators: Validator[], __topLevel?:
  * @param fieldValue
  */
 export function field<T>(validators: Validator[], fieldValue?: T | Ref<T>): Field<T> {
-  const value = ref(fieldValue)
-  const invalid = ref(false)
   const errors: string[] = []
   const errorMessages: string[] = []
   let __topLevel: FieldGroup | undefined = undefined
 
   const fieldObj = reactive<Field>({
-    value,
-    invalid,
+    value: fieldValue,
+    invalid: false,
     errors,
     errorMessages
   } as Field)
 
   fieldObj.__kind = 'Field'
-  fieldObj.clear = () => internalClear(errors, errorMessages, invalid)
+  fieldObj.clear = () => internalClear(errors, errorMessages, toRef(fieldObj, 'invalid'))
   fieldObj.hasError = (name: string) => internalHasError(errors, name)
   fieldObj.addValidator = (validator: Validator) => internalAddValidator(validators, validator)
   fieldObj.removeValidator = (validator: string | Validator) => internalRemoveValidator(validators, validator)

--- a/src/fieldGroup.ts
+++ b/src/fieldGroup.ts
@@ -1,4 +1,4 @@
-import { Ref, reactive, computed, toRef, ComputedRef } from 'vue'
+import { computed, reactive, Ref, toRef } from 'vue'
 import { Field } from '.'
 import { getFromFields, getValueFromFields } from './utils'
 
@@ -12,7 +12,7 @@ export interface FieldGroup {
    * If the field group is currently considered invalid (did not pass latest validation).
    * `true` if any fields / field groups are invalid, `false` if all are valid.
    */
-  invalid: boolean | Ref<boolean> | ComputedRef<boolean>
+  invalid: boolean
   /**
    * Validate all fields within the field group.
    * Optionally, provide a name to validate a specific field / field group.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export function getFromFields(fields: FieldGroupProps, fieldName: string): Field
       tempPath += `${parts[i]}`
       const field = fields[tempPath]
       if (isFieldGroup(field)) {
-        return (field as FieldGroup).get(parts.splice(i + 1).join('.'))
+        return field.get(parts.splice(i + 1).join('.'))
       }
       tempPath += '.'
     }
@@ -22,16 +22,16 @@ export function getFromFields(fields: FieldGroupProps, fieldName: string): Field
 export function getValueFromFields(fields: FieldGroupProps, fieldName: string): any {
   const field = getFromFields(fields, fieldName)
   if (isField(field)) {
-    return (field as Field).value
+    return field.value
   }
   return null
 }
 
-export function isField(f: any): boolean {
+export function isField(f: any): f is Field {
   return Boolean(f && f.__kind === 'Field')
 }
 
-export function isFieldGroup(f: any): boolean {
+export function isFieldGroup(f: any): f is FieldGroup {
   return Boolean(f && f.__kind === 'FieldGroup')
 }
 


### PR DESCRIPTION
* Update `Field` types for properties: `value`, `invalid`
* Update `FieldGroup` type for property: `invalid`
* Update type guards for `Field` and `FieldGroup`
* Update api documentation
* Bump prismjs from 1.25.0 to 1.27.0